### PR TITLE
use bitwise operators to determine Contains

### DIFF
--- a/bamflags.go
+++ b/bamflags.go
@@ -18,11 +18,15 @@ func ParseInt(bamInt int64) (opts []int, err error) {
 	binary := fmt.Sprintf("%b", bamInt)
 	splitBin := strings.Split(binary, "")
 
-	for idx, bit := range splitBin {
+	// Start from the end (least significant bits), so the
+	// resulting slice is in ascending bit order
+	for idx := len(splitBin) - 1; idx >= 0; idx-- {
+		bit := splitBin[idx]
 		if bit == on {
-			sig := len(splitBin) - idx
-			opts = append(opts, Significance(sig))
+			column := len(splitBin) - idx
+			opts = append(opts, Significance(column))
 		}
+
 	}
 	return
 }
@@ -34,23 +38,12 @@ func ParseInt(bamInt int64) (opts []int, err error) {
 // | binary #     | 1 | 0 | 0 | 1 |
 func Significance(column int) int {
 	num := float64(column)
-	out := math.Exp2(num - 1)
+	out := math.Exp2(num - 1) // 2 ^ column
 	return int(out)
 }
 
 // Contains will tell the caller whether or not a certain flag
 // within the provided Binary Access Map is set
-func Contains(binMap, bitValue int64) (isSet bool, err error) {
-	values, err := ParseInt(binMap)
-	if err != nil {
-		return
-	}
-
-	for _, bit := range values {
-		if int64(bit) == bitValue {
-			isSet = true
-			return
-		}
-	}
-	return
+func Contains(binMap, bitValue int64) (isSet bool) {
+	return binMap&bitValue != 0
 }

--- a/bamflags_test.go
+++ b/bamflags_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestParseInt(t *testing.T) {
 	input := int64(515)
-	expect := []int{512, 2, 1}
+	expect := []int{1, 2, 512}
 	got, err := ParseInt(input)
 
 	assert.Equal(t, expect, got)
@@ -29,15 +29,13 @@ func TestSignificance(t *testing.T) {
 func TestContains(t *testing.T) {
 	input := int64(514)
 	expect := true
-	got, err := Contains(input, int64(2))
+	got := Contains(input, int64(2))
 
 	assert.Equal(t, expect, got)
-	assert.Nil(t, err)
 
 	input = int64(520)
 	expect = false
-	got, err = Contains(input, int64(2))
+	got = Contains(input, int64(2))
 
 	assert.Equal(t, expect, got)
-	assert.Nil(t, err)
 }


### PR DESCRIPTION
  * ParseInt returns comprising ints in ascending order
  * tests modified to account for new return values
  * remote returned error from Contains